### PR TITLE
Replace env() with config()

### DIFF
--- a/src/Khalti.php
+++ b/src/Khalti.php
@@ -3,6 +3,7 @@
 namespace Anoop\Khalti;
 
 use Illuminate\Database\Eloquent\Model;
+use \Illuminate\Support\Facades\App;
 
 class Khalti extends Model
 {
@@ -13,7 +14,7 @@ class Khalti extends Model
      * @var array
      */
     protected $fillable = [
-        'user_id', 'mobile' ,'amount' , 'pre_token','status','verified_token'
+        'user_id', 'mobile', 'amount', 'pre_token', 'status', 'verified_token'
     ];
 
     /**
@@ -22,4 +23,18 @@ class Khalti extends Model
      * @var array
      */
     protected $hidden = [''];
+
+    public function getPublicKey()
+    {
+        return  App::environment('production')
+            ? config('khalti.live_public')
+            : config('khalti.test_public');
+    }
+
+    public function getSecretKey()
+    {
+        return  App::environment('production')
+            ? config('khalti.live_secret')
+            : config('khalti.test_secret');
+    }
 }

--- a/src/KhaltiController.php
+++ b/src/KhaltiController.php
@@ -17,7 +17,9 @@ class KhaltiController extends Controller
 
     public function showPurchaseForm()
     {
-    	return view('khalti::index');
+    	return view('khalti::index', [
+            'publicKey' => $this->khalti->getPublicKey(),
+        ]);
     }
 
     //Intial Transaction
@@ -71,7 +73,7 @@ class KhaltiController extends Controller
         curl_setopt($ch, CURLOPT_POSTFIELDS,$args);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 
-        $headers = ['Authorization: Key '.env('KHALTI_TEST_SECRET', '')];
+        $headers = ['Authorization: Key ' .  $this->khalti->getSecretKey()];
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 
         // Response

--- a/src/config/khalti.php
+++ b/src/config/khalti.php
@@ -4,17 +4,17 @@ return [
 		TEST KEYS
 		Public Test key
 		*/
-		'test_public' => 'test_public_key_0be0cce18982449a9b004c13c7c5303f',
+		'test_public' => env('KHALTI_TEST_PUBLIC', 'test_public_key_0be0cce18982449a9b004c13c7c5303f'),
 
 		/*Public Secret key*/
-		'test_secret' => 'test_secret_key_6195fea4d0cd48b49297ebcd6c7c6fb3',
+		'test_secret' => env('KHALTI_TEST_SECRET', 'test_secret_key_6195fea4d0cd48b49297ebcd6c7c6fb3'),
 
 		/*
 		LIVE KEYS
 		Public Live key
 		*/
-		'live_public' => 'live_public_key_0be0cce18982449a9b004c13c7c5303f',
+		'live_public' => env('KHALTI_LIVE_PUBLIC', 'live_public_key_0be0cce18982449a9b004c13c7c5303f'),
 
 		/*Public Secret key*/
-		'live_secret' => 'live_secret_key_6195fea4d0cd48b49297ebcd6c7c6fb3',
+		'live_secret' => env('KHALTI_LIVE_SECRET', 'live_secret_key_6195fea4d0cd48b49297ebcd6c7c6fb3'),
 	];

--- a/src/views/index.blade.php
+++ b/src/views/index.blade.php
@@ -42,7 +42,7 @@
 
 		var config = {
     		// replace the publicKey with yours
-            "publicKey": "{{env('KHALTI_TEST_PUBLIC', '')}}",
+            "publicKey": "{{ $publicKey }}",
             "productIdentity": "1234567890",
             "productName": "Account Topup",
             "productName": "Dragon",


### PR DESCRIPTION
As we know, config values are while caches while the accessing from environment file directly with env() will reach out to file taking more time to execute. Also we have test and live keys which should be used in certain environment. Maybe a KHALTI_MODE will be more appropriate or we can also use the corresponding values according to current app environment.